### PR TITLE
Fixes #17. Added missing fuel resources for RF and TAC-LS

### DIFF
--- a/GameData/KerbalConstructionTime/FuelResources.cfg
+++ b/GameData/KerbalConstructionTime/FuelResources.cfg
@@ -5,6 +5,7 @@ KCT_FUEL_RESOURCES
 	fuelResource = XenonGas
 	fuelResource = MonoPropellant
 	fuelResource = SolidFuel
+    fuelResource = ElectricCharge
 }
 
 KCT_FUEL_RESOURCES:NEEDS[RealFuels]
@@ -35,6 +36,7 @@ KCT_FUEL_RESOURCES:NEEDS[RealFuels]
     fuelResource = LqdMethane
     fuelResource = LqdOxygen
     fuelResource = MMH
+    fuelResource = MON1
     fuelResource = MON10
     fuelResource = MON3
     fuelResource = Methanol
@@ -48,4 +50,21 @@ KCT_FUEL_RESOURCES:NEEDS[RealFuels]
     fuelResource = Tonka500
     fuelResource = UDMH
     fuelResource = UH25
+    fuelResource = Hydrazine
+    fuelResource = Nitrogen
+    fuelResource = Helium
+    fuelResource = CaveaB
+    fuelResource = PSPC
+	fuelResource = HTPB
+	fuelResource = PBAN
+	fuelResource = HNIW
+	fuelResource = NGNC
+    fuelResource = TEATEB
+}
+
+KCT_FUEL_RESOURCES:NEEDS[TacLifeSupport]
+{
+    fuelResource = Water
+    fuelResource = Oxygen
+    fuelResource = Food
 }


### PR DESCRIPTION
Fixes #17 filling tanks doesn't fill EC.
Added missing fuels: EC, various RF monoprops, RF solids, TAC-LS resources.