### PR TITLE
Formula improvements & Airlaunch fix for KRASH

### DIFF
--- a/Kerbal_Construction_Time/AirlaunchParams.cs
+++ b/Kerbal_Construction_Time/AirlaunchParams.cs
@@ -4,7 +4,8 @@ namespace KerbalConstructionTime
 {
     public class AirlaunchParams
     {
-        public Guid VesselId { get; set; }
+        public Guid KCTVesselId { get; set; }
+        public Guid? KSPVesselId { get; set; }
         public double Altitude { get; set; }
         public double KscAzimuth { get; set; }
         public double KscDistance { get; set; }

--- a/Kerbal_Construction_Time/KCT_BuildListVessel.cs
+++ b/Kerbal_Construction_Time/KCT_BuildListVessel.cs
@@ -604,6 +604,7 @@ namespace KerbalConstructionTime
             shipNode.Save(tempFile);
             FlightDriver.StartWithNewLaunch(tempFile, flag, launchSite, new VesselCrewManifest());
             KCT_GameStates.LaunchFromTS = false;
+            if (KCT_GameStates.AirlaunchParams != null) KCT_GameStates.AirlaunchParams.KSPVesselId = null;
         }
 
         public List<string> MeetsFacilityRequirements(bool highestFacility = true)

--- a/Kerbal_Construction_Time/KCT_GUI.cs
+++ b/Kerbal_Construction_Time/KCT_GUI.cs
@@ -2007,7 +2007,7 @@ namespace KerbalConstructionTime
             selectedPadIdx = GUILayout.SelectionGrid(selectedPadIdx, padLvlOptions, 1);
 
             double curPadCost = padCosts[selectedPadIdx];
-            double curPadBuildTime = KCT_UpgradingBuilding.CalculateBuildTime(curPadCost);
+            double curPadBuildTime = KCT_UpgradingBuilding.CalculateBuildTime(curPadCost, SpaceCenterFacility.LaunchPad);
             string sBuildTime = KSPUtil.PrintDateDelta(curPadBuildTime, true);
 
             GUILayout.Label($"It will cost {Math.Round(curPadCost, 2):N} funds to build the new launchpad. " +
@@ -2052,6 +2052,7 @@ namespace KerbalConstructionTime
                     KCT_GameStates.ActiveKSC.LaunchPads.Add(new KCT_LaunchPad(newName, -1));
                     //create new upgradeable
                     KCT_UpgradingBuilding newPad = new KCT_UpgradingBuilding();
+                    newPad.facilityType = SpaceCenterFacility.LaunchPad;
                     newPad.id = KCT_LaunchPad.LPID;
                     newPad.isLaunchpad = true;
                     newPad.launchpadID = KCT_GameStates.ActiveKSC.LaunchPads.Count - 1;

--- a/Kerbal_Construction_Time/KCT_GUI.cs
+++ b/Kerbal_Construction_Time/KCT_GUI.cs
@@ -2228,7 +2228,7 @@ namespace KerbalConstructionTime
             {
                 try
                 {
-                    airlaunchParams.VesselId = KCT_GameStates.launchedVessel.id;
+                    airlaunchParams.KCTVesselId = KCT_GameStates.launchedVessel.id;
                     airlaunchParams.Altitude = double.Parse(sAltitude);
                     airlaunchParams.Velocity = double.Parse(sVelocity);
                     airlaunchParams.LaunchAzimuth = double.Parse(sAzimuth);

--- a/Kerbal_Construction_Time/KCT_GUI_Presets.cs
+++ b/Kerbal_Construction_Time/KCT_GUI_Presets.cs
@@ -254,6 +254,16 @@ namespace KerbalConstructionTime
                 GUILayout.Label("RushCost: ");
                 WorkingPreset.formulaSettings.RushCostFormula = GUILayout.TextField(WorkingPreset.formulaSettings.RushCostFormula, GUILayout.Width(textWidth));
                 GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("AirlaunchCost: ");
+                WorkingPreset.formulaSettings.AirlaunchCostFormula = GUILayout.TextField(WorkingPreset.formulaSettings.AirlaunchCostFormula, GUILayout.Width(textWidth));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("AirlaunchTime: ");
+                WorkingPreset.formulaSettings.AirlaunchTimeFormula = GUILayout.TextField(WorkingPreset.formulaSettings.AirlaunchTimeFormula, GUILayout.Width(textWidth));
+                GUILayout.EndHorizontal();
             }
 
             GUILayout.EndVertical(); 

--- a/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
+++ b/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
@@ -128,6 +128,7 @@ namespace KerbalConstructionTime
             KCTDebug.Log($"Upgrading from level {oldLevel}");
 
             string facilityID = GetFacilityID();
+            SpaceCenterFacility facilityType = GetFacilityType();
 
             string gate = GetTechGate(facilityID, oldLevel + 1);
             KCTDebug.Log("[KCTT] Gate for " + facilityID + "? " + gate);
@@ -147,7 +148,7 @@ namespace KerbalConstructionTime
                 }
             }
 
-            KCT_UpgradingBuilding upgrading = new KCT_UpgradingBuilding(facilityID, oldLevel + 1, oldLevel, facilityID.Split('/').Last());
+            KCT_UpgradingBuilding upgrading = new KCT_UpgradingBuilding(facilityType, facilityID, oldLevel + 1, oldLevel, facilityID.Split('/').Last());
 
             upgrading.isLaunchpad = facilityID.ToLower().Contains("launchpad");
             if (upgrading.isLaunchpad)
@@ -205,10 +206,25 @@ namespace KerbalConstructionTime
             _menu.Dismiss(KSCFacilityContextMenu.DismissAction.None);
         }
 
-
         public string GetFacilityID()
         {
             return getMember<SpaceCenterBuilding>("host").Facility.id;
+        }
+
+        public SpaceCenterFacility GetFacilityType()
+        {
+            var scb = getMember<SpaceCenterBuilding>("host");
+            if (scb is AdministrationFacility) return SpaceCenterFacility.Administration;
+            if (scb is AstronautComplexFacility) return SpaceCenterFacility.AstronautComplex;
+            if (scb is LaunchSiteFacility && ((LaunchSiteFacility)scb).facilityType == EditorFacility.VAB) return SpaceCenterFacility.LaunchPad;
+            if (scb is LaunchSiteFacility && ((LaunchSiteFacility)scb).facilityType == EditorFacility.SPH) return SpaceCenterFacility.Runway;
+            if (scb is MissionControlBuilding) return SpaceCenterFacility.MissionControl;
+            if (scb is RnDBuilding) return SpaceCenterFacility.ResearchAndDevelopment;
+            if (scb is SpacePlaneHangarBuilding) return SpaceCenterFacility.SpaceplaneHangar;
+            if (scb is TrackingStationBuilding) return SpaceCenterFacility.TrackingStation;
+            if (scb is VehicleAssemblyBuilding) return SpaceCenterFacility.VehicleAssemblyBuilding;
+
+            throw new Exception($"Invalid facility type {scb.GetType().Name}");
         }
     }
 }

--- a/Kerbal_Construction_Time/KerbalConstructionTime.cs
+++ b/Kerbal_Construction_Time/KerbalConstructionTime.cs
@@ -418,9 +418,12 @@ namespace KerbalConstructionTime
                     if (alPrep != null)
                         KCT_GameStates.ActiveKSC.AirlaunchPrep.Remove(alPrep);
 
-                    if (KCT_GameStates.AirlaunchParams != null && KCT_GameStates.AirlaunchParams.VesselId == KCT_GameStates.launchedVessel.id)
+                    AirlaunchParams alParams = KCT_GameStates.AirlaunchParams;
+                    if (alParams != null && alParams.KCTVesselId == KCT_GameStates.launchedVessel.id &&
+                        (!alParams.KSPVesselId.HasValue || alParams.KSPVesselId == FlightGlobals.ActiveVessel.id))
                     {
-                        StartCoroutine(AirlaunchRoutine(KCT_GameStates.AirlaunchParams, FlightGlobals.ActiveVessel.id));
+                        if (!alParams.KSPVesselId.HasValue) alParams.KSPVesselId = FlightGlobals.ActiveVessel.id;
+                        StartCoroutine(AirlaunchRoutine(alParams, FlightGlobals.ActiveVessel.id));
                     }
                 }
             }


### PR DESCRIPTION
* Add airlaunch cost and time formulas to the settings editor
* Improve facility upgrade time formula to allow per-facility-type shenanigans (this is specifically meant for RP-1)
* Fix Airlaunch persisting to a KRASH sim