### PR TITLE
Make launchpads non-upgradeable and add option to delete them

### DIFF
--- a/Kerbal_Construction_Time/KCT_GUI.cs
+++ b/Kerbal_Construction_Time/KCT_GUI.cs
@@ -15,8 +15,8 @@ namespace KerbalConstructionTime
     {
         public static bool showMainGUI, showEditorGUI, showSOIAlert, showLaunchAlert, showTimeRemaining,
             showBuildList, showClearLaunch, showShipRoster, showCrewSelect, showSettings, showUpgradeWindow,
-            showBLPlus, showNewPad, showRename, showFirstRun, showLaunchSiteSelector, showBuildPlansWindow,
-            showAirlaunch;
+            showBLPlus, showNewPad, showRename, showDismantlePad, showFirstRun, showLaunchSiteSelector,
+            showBuildPlansWindow, showAirlaunch;
 
         public static bool clicked = false;
 
@@ -91,6 +91,8 @@ namespace KerbalConstructionTime
                     upgradePosition = ClickThruBlocker.GUILayoutWindow(KCT_WindowHelper.NextWindowId("DrawUpgradeWindow"), upgradePosition, KCT_GUI.DrawUpgradeWindow, "Upgrades", HighLogic.Skin.window);
                 if (showBLPlus)
                     bLPlusPosition = ClickThruBlocker.GUILayoutWindow(KCT_WindowHelper.NextWindowId("DrawBLPlusWindow"), bLPlusPosition, KCT_GUI.DrawBLPlusWindow, "Options", HighLogic.Skin.window);
+                if (showDismantlePad)
+                    centralWindowPosition = ClickThruBlocker.GUILayoutWindow(KCT_WindowHelper.NextWindowId("DrawDismantlePadWindow"), centralWindowPosition, KCT_GUI.DrawDismantlePadWindow, "Dismantle pad", HighLogic.Skin.window);
                 if (showRename)
                     centralWindowPosition = ClickThruBlocker.GUILayoutWindow(KCT_WindowHelper.NextWindowId("DrawRenameWindow"), centralWindowPosition, KCT_GUI.DrawRenameWindow, "Rename", HighLogic.Skin.window);
                 if (showNewPad)
@@ -121,7 +123,7 @@ namespace KerbalConstructionTime
                 }
 
                 //Disable KSC things when certain windows are shown.
-                if (showFirstRun || showRename || showNewPad || showUpgradeWindow || showSettings || showCrewSelect || showShipRoster || showClearLaunch || showAirlaunch)
+                if (showFirstRun || showRename || showNewPad || showDismantlePad || showUpgradeWindow || showSettings || showCrewSelect || showShipRoster || showClearLaunch || showAirlaunch)
                 {
                     if (!isKSCLocked)
                     {
@@ -286,6 +288,7 @@ namespace KerbalConstructionTime
             showUpgradeWindow = false;
             showBLPlus = false;
             showRename = false;
+            showDismantlePad = false;
             showFirstRun = false;
             showPresetSaver = false;
             showLaunchSiteSelector = false;
@@ -1948,6 +1951,39 @@ namespace KerbalConstructionTime
             researchRate = -13;
             upResearchRate = -13;
             costOfNewLP = -13;
+        }
+
+        public static void DrawDismantlePadWindow(int windowID)
+        {
+            GUILayout.BeginVertical();
+            GUILayout.Label("Are you sure you want to dismantle the currently selected launch pad? This cannot be undone!");
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Yes"))
+            {
+                if (KCT_GameStates.ActiveKSC.LaunchPadCount < 2) return;
+
+                KCT_LaunchPad lpToDel = KCT_GameStates.ActiveKSC.ActiveLPInstance;
+                if (!lpToDel.Delete(out string err))
+                {
+                    ScreenMessages.PostScreenMessage("Dismantle failed: " + err, 5f, ScreenMessageStyle.UPPER_CENTER);
+                }
+
+                showDismantlePad = false;
+                showBuildList = true;
+            }
+
+            if (GUILayout.Button("No"))
+            {
+                centralWindowPosition.width = 150;
+                centralWindowPosition.x = (Screen.width - 150) / 2;
+                showDismantlePad = false;
+                showBuildList = true;
+            }
+
+            GUILayout.EndHorizontal();
+            GUILayout.EndVertical();
+            CenterWindow(ref centralWindowPosition);
         }
 
         private static string newName = "";

--- a/Kerbal_Construction_Time/KCT_GUI_BuildList.cs
+++ b/Kerbal_Construction_Time/KCT_GUI_BuildList.cs
@@ -668,6 +668,7 @@ namespace KerbalConstructionTime
                 {
                     renamingLaunchPad = true;
                     newName = KCT_GameStates.ActiveKSC.ActiveLPInstance.name;
+                    showDismantlePad = false;
                     showNewPad = false;
                     showRename = true;
                     showBuildList = false;
@@ -676,7 +677,16 @@ namespace KerbalConstructionTime
                 if (costOfNewLP >= 0 && GUILayout.Button("New", GUILayout.ExpandWidth(false)))
                 {
                     newName = "LaunchPad " + (KCT_GameStates.ActiveKSC.LaunchPads.Count + 1);
+                    showDismantlePad = false;
                     showNewPad = true;
+                    showRename = false;
+                    showBuildList = false;
+                    showBLPlus = false;
+                }
+                if (lpCount > 1 && GUILayout.Button("Dismantle", GUILayout.ExpandWidth(false)))
+                {
+                    showDismantlePad = true;
+                    showNewPad = false;
                     showRename = false;
                     showBuildList = false;
                     showBLPlus = false;

--- a/Kerbal_Construction_Time/KCT_KSC.cs
+++ b/Kerbal_Construction_Time/KCT_KSC.cs
@@ -175,7 +175,7 @@ namespace KerbalConstructionTime
             //LaunchPads[ActiveLaunchPadID].level = KCT_Utilities.BuildingUpgradeLevel(SpaceCenterFacility.LaunchPad);
             //LaunchPads[ActiveLaunchPadID].destroyed = !KCT_Utilities.LaunchFacilityIntact(KCT_BuildListVessel.ListType.VAB); //Might want to remove this as well
             if (updateDestrNode)
-                ActiveLPInstance.RefreshDestructionNode();
+                ActiveLPInstance?.RefreshDestructionNode();
 
             LaunchPads[LP_ID].SetActive();
         }

--- a/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
+++ b/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
@@ -1,11 +1,12 @@
-﻿using KSP.UI.Screens;
+﻿using KSP.UI;
+using KSP.UI.Screens;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace KerbalConstructionTime
 {
@@ -14,7 +15,10 @@ namespace KerbalConstructionTime
     /// </summary>
     public class KCT_KSCContextMenuOverrider
     {
-        KSCFacilityContextMenu _menu = null;
+        protected static Dictionary<string, Dictionary<int, string>> techGatings = null;
+
+        private KSCFacilityContextMenu _menu = null;
+
         public KCT_KSCContextMenuOverrider(KSCFacilityContextMenu menu)
         {
             _menu = menu;
@@ -26,19 +30,29 @@ namespace KerbalConstructionTime
             if (KCT_PresetManager.Instance.ActivePreset.generalSettings.KSCUpgradeTimes && _menu != null)
             {
                 SpaceCenterBuilding hostBuilding = getMember<SpaceCenterBuilding>("host");
-                KCTDebug.Log("Trying to override upgrade button of menu for "+hostBuilding.facilityName);
-                UnityEngine.UI.Button button = getMember<UnityEngine.UI.Button>("UpgradeButton");
+                KCTDebug.Log("Trying to override upgrade button of menu for " + hostBuilding.facilityName);
+                Button button = getMember<Button>("UpgradeButton");
                 if (button == null)
                 {
                     KCTDebug.Log("Could not find UpgradeButton by name, using index instead.", true);
                     button = getMember<UnityEngine.UI.Button>(2);
                 }
+
                 if (button != null)
                 {
                     KCTDebug.Log("Found upgrade button, overriding it.");
-                    button.onClick = new UnityEngine.UI.Button.ButtonClickedEvent(); //Clear existing KSP listener
-                    
-                    button.onClick.AddListener(handleUpgrade);
+                    button.onClick = new Button.ButtonClickedEvent();    //Clear existing KSP listener
+                    button.onClick.AddListener(HandleUpgrade);
+
+                    if (KCT_PresetManager.Instance.ActivePreset.generalSettings.DisableLPUpgrades &&
+                        GetFacilityID().ToLower().Contains("launchpad"))
+                    {
+                        button.interactable = false;
+                        var hov = button.gameObject.GetComponent<UIOnHover>();
+                        hov.gameObject.DestroyGameObject();
+
+                        _menu.levelStatsText.text = "<color=red><b>Launchpads cannot be upgraded. Build a new launchpad from the KCT menu instead.</b></color>";
+                    }
                 }
                 else
                 {
@@ -82,8 +96,6 @@ namespace KerbalConstructionTime
             return default(T);
         }
 
-        protected static Dictionary<string, Dictionary<int, string>> techGatings = null;
-
         protected static void CheckLoadDict()
         {
             if (techGatings != null)
@@ -122,7 +134,7 @@ namespace KerbalConstructionTime
             return string.Empty;
         }
 
-        internal void processUpgrade()
+        internal void ProcessUpgrade()
         {
             int oldLevel = getMember<int>("level");
             KCTDebug.Log($"Upgrading from level {oldLevel}");
@@ -186,7 +198,7 @@ namespace KerbalConstructionTime
 
         void stub() { }
 
-        internal void handleUpgrade()
+        internal void HandleUpgrade()
         {
             if (GetFacilityID().ToLower().Contains("launchpad"))
             {
@@ -194,13 +206,13 @@ namespace KerbalConstructionTime
                             "Upgrading this launchpad will render it unusable until the upgrade finishes.\n\nAre you sure you want to?",
                             "Upgrade Launchpad?",
                             HighLogic.UISkin,
-                            new DialogGUIButton("Yes", processUpgrade),
+                            new DialogGUIButton("Yes", ProcessUpgrade),
                             new DialogGUIButton("No", stub)),
                             false,
                             HighLogic.UISkin);
             }
             else
-                processUpgrade();
+                ProcessUpgrade();
 
             _menu.Dismiss(KSCFacilityContextMenu.DismissAction.None);
         }

--- a/Kerbal_Construction_Time/KCT_PresetManager.cs
+++ b/Kerbal_Construction_Time/KCT_PresetManager.cs
@@ -317,7 +317,7 @@ namespace KerbalConstructionTime
     {
         [Persistent]
         public bool Enabled = true, BuildTimes = true, ReconditioningTimes = true, ReconditioningBlocksPad = false, TechUnlockTimes = true, KSCUpgradeTimes = true,
-            TechUpgrades = true, SharedUpgradePool = false;
+            TechUpgrades = true, SharedUpgradePool = false, DisableLPUpgrades = false;
         [Persistent]
         public string StartingPoints = "15,15,45", //Career, Science, and Sandbox modes
             VABRecoveryTech = null;


### PR DESCRIPTION
These changes are specifically meant for RP-1. Upgrading the supported tonnage of pads doesn't make any sense from the realism perspective. If something like that would be needed then it would be cheaper to build a new pad nearby compared to reinforcing an existing one.
Because of that, the dismantle option is now needed since the first 2 pad levels lose their usefulness in the mid- to lategame.

Edit: by default LPs are still upgradeable and this limitation needs to be enabled through the KCT profile.