### PR TITLE
Improve TransactionReasons usage

### DIFF
--- a/Kerbal_Construction_Time/KCT_AirlaunchPrep.cs
+++ b/Kerbal_Construction_Time/KCT_AirlaunchPrep.cs
@@ -110,7 +110,7 @@ namespace KerbalConstructionTime
                         }
                     }
                     else
-                        KCT_Utilities.SpendFunds(cost / 10 * steps, TransactionReasons.None);
+                        KCT_Utilities.SpendFunds(cost / 10 * steps, TransactionReasons.VesselRollout);
                 }
             }
         }

--- a/Kerbal_Construction_Time/KCT_BuildListVessel.cs
+++ b/Kerbal_Construction_Time/KCT_BuildListVessel.cs
@@ -840,7 +840,7 @@ namespace KerbalConstructionTime
 
             double remainingBP = buildPoints + integrationPoints - progress;
             AddProgress(remainingBP * 0.1);
-            KCT_Utilities.SpendFunds(rushCost, TransactionReasons.None);
+            KCT_Utilities.SpendFunds(rushCost, TransactionReasons.VesselRollout);
             ++rushBuildClicks;
             this.rushCost = -1;    // force recalculation of rush cost
 

--- a/Kerbal_Construction_Time/KCT_Recon_Rollout.cs
+++ b/Kerbal_Construction_Time/KCT_Recon_Rollout.cs
@@ -263,7 +263,7 @@ namespace KerbalConstructionTime
                         }
                     }
                     else
-                        KCT_Utilities.SpendFunds(cost / 10 * steps, TransactionReasons.None);
+                        KCT_Utilities.SpendFunds(cost / 10 * steps, TransactionReasons.VesselRollout);
                 }
             }
         }


### PR DESCRIPTION
All spent funds that are related to vessel building & rollout are now logged under TransactionReasons.VesselRollout.
This is rather important for RP-1 career logger.