### PR TITLE
Custom facility type fix

### DIFF
--- a/Kerbal_Construction_Time/KCT_KSC.cs
+++ b/Kerbal_Construction_Time/KCT_KSC.cs
@@ -289,7 +289,7 @@ namespace KerbalConstructionTime
             foreach (KCT_UpgradingBuilding buildingTech in KSCTech)
             {
                 ConfigNode bT = new ConfigNode("UpgradingBuilding");
-                bT = ConfigNode.CreateConfigFromObject(buildingTech, bT);
+                buildingTech.Save(bT);
                 upgradeables.AddNode(bT);
             }
             node.AddNode(upgradeables);
@@ -504,7 +504,7 @@ namespace KerbalConstructionTime
                 foreach (ConfigNode upBuild in tmp.GetNodes("UpgradingBuilding"))
                 {
                     KCT_UpgradingBuilding tempUP = new KCT_UpgradingBuilding();
-                    ConfigNode.LoadObjectFromConfig(tempUP, upBuild);
+                    tempUP.Load(upBuild);
                     KSCTech.Add(tempUP);
                 }
             }

--- a/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
+++ b/Kerbal_Construction_Time/KCT_KSCUpgradeOverrider.cs
@@ -140,7 +140,7 @@ namespace KerbalConstructionTime
             KCTDebug.Log($"Upgrading from level {oldLevel}");
 
             string facilityID = GetFacilityID();
-            SpaceCenterFacility facilityType = GetFacilityType();
+            SpaceCenterFacility? facilityType = GetFacilityType();
 
             string gate = GetTechGate(facilityID, oldLevel + 1);
             KCTDebug.Log("[KCTT] Gate for " + facilityID + "? " + gate);
@@ -232,7 +232,7 @@ namespace KerbalConstructionTime
             return getMember<SpaceCenterBuilding>("host").Facility.id;
         }
 
-        public SpaceCenterFacility GetFacilityType()
+        public SpaceCenterFacility? GetFacilityType()
         {
             var scb = getMember<SpaceCenterBuilding>("host");
             if (scb is AdministrationFacility) return SpaceCenterFacility.Administration;
@@ -245,7 +245,8 @@ namespace KerbalConstructionTime
             if (scb is TrackingStationBuilding) return SpaceCenterFacility.TrackingStation;
             if (scb is VehicleAssemblyBuilding) return SpaceCenterFacility.VehicleAssemblyBuilding;
 
-            throw new Exception($"Invalid facility type {scb.GetType().Name}");
+            // Some mods define custom facilities
+            return null;
         }
     }
 }


### PR DESCRIPTION
Apparently there are mods that define custom KSC facility types. Those cannot currently be resolved to the KSP SpaceCenterFacility enum and will cause facility upgrade attempts to fail.
I made KCT_UpgradingBuilding.facilityType field nullable so that any custom facilities would just be null there. In the process I also found out that KSP is unable to automatically persist nullable enums so a workaround had to be written for that.
