### PR TITLE
Setting isKCTBuilt = true fields for all the modules KCT sees in the ship's config tree

### DIFF
--- a/Kerbal_Construction_Time/KCT_Events.cs
+++ b/Kerbal_Construction_Time/KCT_Events.cs
@@ -485,16 +485,7 @@ namespace KerbalConstructionTime
                         KCT_GameStates.recoveredVessel.integrationPoints = KCT_MathParsing.ParseIntegrationTimeFormula(KCT_GameStates.recoveredVessel);
                     }
 
-                    foreach (ConfigNode partNode in KCT_GameStates.recoveredVessel.shipNode.nodes)
-                    {
-                        if (partNode.name == "PART")
-                        {
-                            foreach (ConfigNode partModuleNode in partNode.nodes)       // Not all of .nodes are nodes of modules, but nobody cares
-                            {
-                                partModuleNode.SetValue("isKCTBuilt", true, false);
-                            }
-                        }
-                    }
+                    KCT_Utilities.SetIsKCTBuiltFlags(KCT_GameStates.recoveredVessel.shipNode);
 
                     if (KCT_GameStates.recoveredVessel.type == KCT_BuildListVessel.ListType.VAB)
                     {

--- a/Kerbal_Construction_Time/KCT_Events.cs
+++ b/Kerbal_Construction_Time/KCT_Events.cs
@@ -31,7 +31,6 @@ namespace KerbalConstructionTime
         {
             GameEvents.onGUILaunchScreenSpawn.Add(launchScreenOpenEvent);
             GameEvents.onVesselRecovered.Add(vesselRecoverEvent);
-            //GameEvents.onAboutToSaveShip.Add(OnAboutToSaveShipEvent);
 
             //GameEvents.onLaunch.Add(vesselSituationChange);
             GameEvents.onVesselSituationChange.Add(vesselSituationChange);
@@ -511,20 +510,6 @@ namespace KerbalConstructionTime
                 }
             }
         }
-
-        /*public void OnAboutToSaveShipEvent(ShipConstruct sc)
-        {
-            foreach (Part p in sc.parts)
-            {
-                foreach (PartModule pm in p.Modules)
-                {
-                    if (pm.Fields["isKCTBuilt"] != null)
-                    {
-                        pm.Fields["isKCTBuilt"].SetValue(false, pm);
-                    }
-                }
-            }
-        }*/
 
 
         private float GetResourceMass(List<ProtoPartResourceSnapshot> resources)

--- a/Kerbal_Construction_Time/KCT_Events.cs
+++ b/Kerbal_Construction_Time/KCT_Events.cs
@@ -485,7 +485,11 @@ namespace KerbalConstructionTime
                         KCT_GameStates.recoveredVessel.integrationPoints = KCT_MathParsing.ParseIntegrationTimeFormula(KCT_GameStates.recoveredVessel);
                     }
 
-                    KCT_Utilities.SetIsKCTBuiltFlags(KCT_GameStates.recoveredVessel.shipNode);
+                    if (SpaceTuxUtility.HasMod.hasMod("EngineDecay"))
+                    {
+                        KCTDebug.Log("Setting isKCTBuilt flags as P2P mod is present");
+                        KCT_Utilities.SetIsKCTBuiltFlags(KCT_GameStates.recoveredVessel.shipNode);
+                    }
 
                     if (KCT_GameStates.recoveredVessel.type == KCT_BuildListVessel.ListType.VAB)
                     {

--- a/Kerbal_Construction_Time/KCT_Events.cs
+++ b/Kerbal_Construction_Time/KCT_Events.cs
@@ -31,6 +31,7 @@ namespace KerbalConstructionTime
         {
             GameEvents.onGUILaunchScreenSpawn.Add(launchScreenOpenEvent);
             GameEvents.onVesselRecovered.Add(vesselRecoverEvent);
+            //GameEvents.onAboutToSaveShip.Add(OnAboutToSaveShipEvent);
 
             //GameEvents.onLaunch.Add(vesselSituationChange);
             GameEvents.onVesselSituationChange.Add(vesselSituationChange);
@@ -484,6 +485,18 @@ namespace KerbalConstructionTime
                         KCT_GameStates.recoveredVessel.buildPoints = KCT_Utilities.GetBuildTime(KCT_GameStates.recoveredVessel.ExtractedPartNodes);
                         KCT_GameStates.recoveredVessel.integrationPoints = KCT_MathParsing.ParseIntegrationTimeFormula(KCT_GameStates.recoveredVessel);
                     }
+
+                    foreach (ConfigNode partNode in KCT_GameStates.recoveredVessel.shipNode.nodes)
+                    {
+                        if (partNode.name == "PART")
+                        {
+                            foreach (ConfigNode partModuleNode in partNode.nodes)       // Not all of .nodes are nodes of modules, but nobody cares
+                            {
+                                partModuleNode.SetValue("isKCTBuilt", true, false);
+                            }
+                        }
+                    }
+
                     if (KCT_GameStates.recoveredVessel.type == KCT_BuildListVessel.ListType.VAB)
                     {
                         KCT_GameStates.ActiveKSC.VABWarehouse.Add(KCT_GameStates.recoveredVessel);
@@ -498,6 +511,20 @@ namespace KerbalConstructionTime
                 }
             }
         }
+
+        /*public void OnAboutToSaveShipEvent(ShipConstruct sc)
+        {
+            foreach (Part p in sc.parts)
+            {
+                foreach (PartModule pm in p.Modules)
+                {
+                    if (pm.Fields["isKCTBuilt"] != null)
+                    {
+                        pm.Fields["isKCTBuilt"].SetValue(false, pm);
+                    }
+                }
+            }
+        }*/
 
 
         private float GetResourceMass(List<ProtoPartResourceSnapshot> resources)

--- a/Kerbal_Construction_Time/KCT_Utilities.cs
+++ b/Kerbal_Construction_Time/KCT_Utilities.cs
@@ -902,7 +902,11 @@ namespace KerbalConstructionTime
 
         public static KCT_BuildListVessel AddVesselToBuildList(KCT_BuildListVessel blv)
         {
-            SetIsKCTBuiltFlags(blv.shipNode);
+            if (SpaceTuxUtility.HasMod.hasMod("EngineDecay"))
+            {
+                KCTDebug.Log("Setting isKCTBuilt flags as P2P mod is present");
+                KCT_Utilities.SetIsKCTBuiltFlags(blv.shipNode);
+            }
 
             if (CurrentGameIsCareer())
             {

--- a/Kerbal_Construction_Time/KCT_Utilities.cs
+++ b/Kerbal_Construction_Time/KCT_Utilities.cs
@@ -902,16 +902,7 @@ namespace KerbalConstructionTime
 
         public static KCT_BuildListVessel AddVesselToBuildList(KCT_BuildListVessel blv)
         {
-            foreach (ConfigNode partNode in blv.shipNode.nodes)
-            {
-                if (partNode.name == "PART")
-                {
-                    foreach (ConfigNode partModuleNode in partNode.nodes)       // Not all of .nodes are nodes of modules, but nobody cares
-                    {
-                        partModuleNode.SetValue("isKCTBuilt", true, false);
-                    }
-                }
-            }
+            SetIsKCTBuiltFlags(blv.shipNode);
 
             if (CurrentGameIsCareer())
             {
@@ -1933,6 +1924,20 @@ namespace KerbalConstructionTime
                    (FlightGlobals.ActiveVessel.situation == Vessel.Situations.PRELAUNCH ||
                     string.IsNullOrEmpty(reqTech) ||
                     ResearchAndDevelopment.GetTechnologyState(reqTech) == RDTech.State.Available);
+        }
+
+        public static void SetIsKCTBuiltFlags(ConfigNode shipNode)
+        {
+            foreach (ConfigNode partNode in shipNode.nodes)
+            {
+                if (partNode.name == "PART")
+                {
+                    foreach (ConfigNode partModuleNode in partNode.nodes)       // Not all of .nodes are nodes of modules, but nobody cares
+                    {
+                        partModuleNode.SetValue("isKCTBuilt", true, false);
+                    }
+                }
+            }
         }
     }
 }

--- a/Kerbal_Construction_Time/KCT_Utilities.cs
+++ b/Kerbal_Construction_Time/KCT_Utilities.cs
@@ -902,6 +902,17 @@ namespace KerbalConstructionTime
 
         public static KCT_BuildListVessel AddVesselToBuildList(KCT_BuildListVessel blv)
         {
+            foreach (ConfigNode partNode in blv.shipNode.nodes)
+            {
+                if (partNode.name == "PART")
+                {
+                    foreach (ConfigNode partModuleNode in partNode.nodes)       // Not all of .nodes are nodes of modules, but nobody cares
+                    {
+                        partModuleNode.SetValue("isKCTBuilt", true, false);
+                    }
+                }
+            }
+
             if (CurrentGameIsCareer())
             {
                 //Check upgrades


### PR DESCRIPTION
This code does a simple trick. 
Each ship added to build list or to storage via recovery is checked for isKCTBuilt fields in modules and these fields are set to true. The affected modules should set it back to false on their own in order not to get foolished if a ship is saved in such a state.

I have done it for consistency of automatic reliability updates in my PayToPlay mod (this [issue](https://github.com/DarthPointer/PayToPlay/issues/25)). I'd like to release P2P 1.5.0 using this feature by the end of July.
Any other mod can use this feature, provided that its module has a bool "isKCTBuilt" field and sets it to false before its part is saved as a part of a ship or a subassembly.